### PR TITLE
Possible solution to two new NMOESI issues -- Requires validation of the entire amdappsdk

### DIFF
--- a/src/arch/southern-islands/driver/DriverCall.cc
+++ b/src/arch/southern-islands/driver/DriverCall.cc
@@ -902,6 +902,13 @@ int Driver::CallNDRangeFree(comm::Context *context,
 		throw Error(misc::fmt("%s: invalid ndrange ID (%d)", 
 			__FUNCTION__, ndrange_id));
 
+	// Unmap NDRange if it is timing
+	if (Timing::getSimKind() == comm::Arch::SimDetailed)
+	{
+		Gpu *gpu = Timing::getInstance()->getGpu();
+		gpu->UnmapNDRange(ndrange);
+	}
+
 	// Free       
 	emulator->RemoveNDRange(ndrange);
 

--- a/src/arch/southern-islands/driver/DriverCall.cc
+++ b/src/arch/southern-islands/driver/DriverCall.cc
@@ -614,18 +614,6 @@ int Driver::CallNDRangeCreate(comm::Context *context,
 	// Set the global and local sizes
 	ndrange->SetupSize(global_size, local_size, work_dim);
 
-	// Calculate the allowed work groups per wavefront pool and 
-	// compute unit. Create the address space for the MMU.
-	
-	// Get gpu object from timing instance
-	if (Timing::getSimKind() == comm::Arch::SimDetailed)
-	{
-		Gpu *gpu  = Timing::getInstance()->getGpu();
-	 	gpu->MapNDRange(ndrange);
-		ndrange->address_space = gpu->getMmu()
-				->newSpace("Southern Islands");
-	}
-	
 	// Return ID of new nd-range 
 	return ndrange->getId();
 }
@@ -736,30 +724,28 @@ int Driver::CallNDRangeFinish(comm::Context *context,
 	NDRange *ndrange = emulator->getNDRangeById(ndrange_id);
 	
 	// Check for ndrange
-	if (!ndrange)                                                            
+	if (!ndrange)
 		throw Error(misc::fmt("%s: invalid ndrange ID (%d)",
-				__FUNCTION__, ndrange_id));  
+				__FUNCTION__, ndrange_id));
 	
-	// Last work group has been sent
-	ndrange->setLastWorkgroupSent(true);
-
-	// If no work-groups are left in the queues, remove the nd-range         
-	// from the driver list                                           
-	if (!(ndrange->getNumWorkgroups()) &&                         
-			!(ndrange->getNumWaitingWorkgroups()))                       
-	{                                   
-		// The NDRange has finished 
-		debug << misc::fmt("\tnd-range %d finished\n", ndrange_id);            
-	}                                                                        
-	else                                                                     
+	// If no work-groups are left in the queues, remove the nd-range
+	// from the driver list
+	if (!(ndrange->getNumWorkgroups()) &&
+			!(ndrange->getNumWaitingWorkgroups()) &&
+			(ndrange->LastWorkGroupSent()))
+	{
+		// The NDRange has finished
+		debug << misc::fmt("\tnd-range %d finished\n", ndrange_id);
+	}
+	else
 	{
 		// The NDRange has not finished. Suspend the context until it
 		// completes
-		debug << misc::fmt("\twaiting for nd-range %d to finish (blocking)\n", 
+		debug << misc::fmt("\twaiting for nd-range %d to finish (blocking)\n",
 				ndrange_id);
 		context->Suspend();
 		ndrange->SetSuspendedContext(context);
-	}                                                                 
+	}
 
 	// Return
 	return 0;
@@ -837,7 +823,7 @@ int Driver::CallNDRangeSetFused(comm::Context *context,
 	// else                                                                     
 	//{                                                                       
 	
-	debug << misc::fmt("\tnot fused\n");                                                                                                           
+	debug << misc::fmt("\tnot fused\n");
 
 	// Return
 	return 0;
@@ -901,13 +887,6 @@ int Driver::CallNDRangeFree(comm::Context *context,
 	if (!ndrange)
 		throw Error(misc::fmt("%s: invalid ndrange ID (%d)", 
 			__FUNCTION__, ndrange_id));
-
-	// Unmap NDRange if it is timing
-	if (Timing::getSimKind() == comm::Arch::SimDetailed)
-	{
-		Gpu *gpu = Timing::getInstance()->getGpu();
-		gpu->UnmapNDRange(ndrange);
-	}
 
 	// Free       
 	emulator->RemoveNDRange(ndrange);

--- a/src/arch/southern-islands/emulator/NDRange.h
+++ b/src/arch/southern-islands/emulator/NDRange.h
@@ -447,6 +447,9 @@ public:
 	/// Set last_work_group_sent
 	void setLastWorkgroupSent(bool value) { last_work_group_sent = value; }
 
+	/// Has the last work group sent
+	bool LastWorkGroupSent() const { return last_work_group_sent; }
+
 	/// Set const_buf_table
 	void setConstBufferTable(unsigned value) { const_buf_table = value; }
 

--- a/src/arch/southern-islands/timing/ComputeUnit.cc
+++ b/src/arch/southern-islands/timing/ComputeUnit.cc
@@ -548,6 +548,9 @@ void ComputeUnit::AddWorkGroup(WorkGroup *work_group)
 
 void ComputeUnit::RemoveWorkGroup(WorkGroup *work_group)
 {
+	// Save timing simulator
+	timing = Timing::getInstance();
+
 	// Debug info
 	Emulator::scheduler_debug << misc::fmt("@%lld work group %d "
 			"removed from compute unit %d slot %d\n",
@@ -565,6 +568,9 @@ void ComputeUnit::RemoveWorkGroup(WorkGroup *work_group)
 
 void ComputeUnit::Reset()
 {
+	// Save timing simulator
+	timing = Timing::getInstance();
+
 	// Debug info
 	Emulator::scheduler_debug << misc::fmt("@%lld compute unit %d "
 			"reset\n",

--- a/src/arch/southern-islands/timing/ComputeUnit.cc
+++ b/src/arch/southern-islands/timing/ComputeUnit.cc
@@ -531,6 +531,7 @@ void ComputeUnit::AddWorkGroup(WorkGroup *work_group)
 		// Set the new work group to the empty entry
 		work_groups[index] = work_group;
 	}
+
 	// Checks
 	assert(work_group->id_in_compute_unit == index);
 
@@ -548,9 +549,6 @@ void ComputeUnit::AddWorkGroup(WorkGroup *work_group)
 
 void ComputeUnit::RemoveWorkGroup(WorkGroup *work_group)
 {
-	// Save timing simulator
-	timing = Timing::getInstance();
-
 	// Debug info
 	Emulator::scheduler_debug << misc::fmt("@%lld work group %d "
 			"removed from compute unit %d slot %d\n",
@@ -568,8 +566,10 @@ void ComputeUnit::RemoveWorkGroup(WorkGroup *work_group)
 
 void ComputeUnit::Reset()
 {
-	// Save timing simulator
-	timing = Timing::getInstance();
+	// If there are no work groups ever assigned to this compute unit
+	// the size would be zero, so no reset is required. 
+	if (!work_groups.size())
+		return;
 
 	// Debug info
 	Emulator::scheduler_debug << misc::fmt("@%lld compute unit %d "

--- a/src/arch/southern-islands/timing/ComputeUnit.cc
+++ b/src/arch/southern-islands/timing/ComputeUnit.cc
@@ -531,6 +531,8 @@ void ComputeUnit::AddWorkGroup(WorkGroup *work_group)
 		// Set the new work group to the empty entry
 		work_groups[index] = work_group;
 	}
+	// Checks
+	assert(work_group->id_in_compute_unit == index);
 
 	// Save iterator 
 	auto it = work_groups.begin();
@@ -554,10 +556,23 @@ void ComputeUnit::RemoveWorkGroup(WorkGroup *work_group)
 			index,
 			work_group->id_in_compute_unit);
 
-	// Erase work group                                                      
+	// Unmap work group from the compute unit
 	assert(work_group->compute_unit_work_groups_iterator != 
 			work_groups.end());
 	work_groups[work_group->id_in_compute_unit] = nullptr;
+}
+
+
+void ComputeUnit::Reset()
+{
+	// Debug info
+	Emulator::scheduler_debug << misc::fmt("@%lld compute unit %d "
+			"reset\n",
+			timing->getCycle(),
+			index);
+
+	// Reset the workgroups size to 0
+	work_groups.resize(0);
 }
 
 
@@ -672,6 +687,32 @@ void ComputeUnit::Run()
 		Fetch(fetch_buffers[i].get(), wavefront_pools[i].get());
 }
 
+
+void ComputeUnit::Dump(std::ostream &os) const
+{
+	// Title
+	std::string output_line = misc::fmt("Compute unit %d", index);	
+	os << output_line  << '\n';
+	os << std::string(output_line.length(), '=') << "\n\n";
+
+	// Number of workgroups and their ids
+	os << "Work group capacity = " <<  work_groups.size() << '\n';
+	for (int i = 0; i < (int) work_groups.size(); i++)
+	{
+		// Get the work group
+		WorkGroup* work_group = work_groups[i];
+
+		// Dump the information
+		output_line = misc::fmt("[%d] work group %d ", i, 
+				work_group->getId());
+	}
+	os << '\n';
+
+	// Is it an available compute unit
+	os << "Compute unit is available : " << (in_available_compute_units ?
+			"True" : "False");
+	os << '\n';
+}
 
 } // Namespace SI
 

--- a/src/arch/southern-islands/timing/ComputeUnit.h
+++ b/src/arch/southern-islands/timing/ComputeUnit.h
@@ -158,6 +158,9 @@ public:
 	/// Constructor
 	ComputeUnit(int index, Gpu *gpu);
 
+	/// Reset the compute unit for the next NDRange
+	void Reset();
+
 	/// Advance compute unit state by one cycle
 	void Run();
 
@@ -188,6 +191,16 @@ public:
 
 	/// Return the associated LDS module
 	mem::Module *getLdsModule() const { return lds_module.get(); }
+
+	// Dump function
+	void Dump(std::ostream &os = std::cout) const;
+
+
+
+
+	//
+	// Public member variables
+	//
 
 	/// Cache used for vector data
 	mem::Module *vector_cache = nullptr;

--- a/src/arch/southern-islands/timing/ComputeUnit.h
+++ b/src/arch/southern-islands/timing/ComputeUnit.h
@@ -195,6 +195,15 @@ public:
 	// Dump function
 	void Dump(std::ostream &os = std::cout) const;
 
+	/// Same as Dump()
+	friend std::ostream &operator<<(std::ostream &os,
+			const ComputeUnit &compute_unit)
+	{
+		compute_unit.Dump(os);
+		return os;
+	}
+
+
 
 
 

--- a/src/arch/southern-islands/timing/Gpu.cc
+++ b/src/arch/southern-islands/timing/Gpu.cc
@@ -134,6 +134,21 @@ void Gpu::MapNDRange(NDRange *ndrange)
 }
 
 
+void Gpu::UnmapNDRange(NDRange* ndrange)
+{
+	// Erase every workgroup in each compute unit, setting the
+	// work_groups size to 0
+	for (int i = 0; i < num_compute_units; i++)
+	{
+		// Get the compute unit
+		ComputeUnit *compute_unit = compute_units[i].get();
+
+		// Erase the workgroups of the compute unit
+		compute_unit->Reset();
+	}
+}
+
+
 void Gpu::CalcGetWorkGroupsPerWavefrontPool(int work_items_per_work_group, 
 		int registers_per_work_item, int local_memory_per_work_group)
 {

--- a/src/arch/southern-islands/timing/Gpu.cc
+++ b/src/arch/southern-islands/timing/Gpu.cc
@@ -130,22 +130,22 @@ void Gpu::MapNDRange(NDRange *ndrange)
 			ndrange->getId(),
 			work_groups_per_wavefront_pool,
 			work_groups_per_compute_unit);
-	
+
+	// Map NDRange to the Gpu
+	mapped_ndrange = ndrange;
 }
 
 
-void Gpu::UnmapNDRange(NDRange* ndrange)
+void Gpu::UnmapNDRange(NDRange *ndrange)
 {
-	// Erase every workgroup in each compute unit, setting the
-	// work_groups size to 0
-	for (int i = 0; i < num_compute_units; i++)
-	{
-		// Get the compute unit
-		ComputeUnit *compute_unit = compute_units[i].get();
+	// Unmap the NDRange
+	assert(mapped_ndrange == ndrange);
+	mapped_ndrange = nullptr;
 
-		// Erase the workgroups of the compute unit
+	//Erase every workgroup in each compute unit, setting the
+	// work_groups size to 0
+	for (auto &compute_unit : compute_units)
 		compute_unit->Reset();
-	}
 }
 
 

--- a/src/arch/southern-islands/timing/Gpu.cc
+++ b/src/arch/southern-islands/timing/Gpu.cc
@@ -131,15 +131,14 @@ void Gpu::MapNDRange(NDRange *ndrange)
 			work_groups_per_wavefront_pool,
 			work_groups_per_compute_unit);
 
-	// Map NDRange to the Gpu
+	// Map ndrange
 	mapped_ndrange = ndrange;
 }
 
 
 void Gpu::UnmapNDRange(NDRange *ndrange)
 {
-	// Unmap the NDRange
-	assert(mapped_ndrange == ndrange);
+	// Unmap NDRange
 	mapped_ndrange = nullptr;
 
 	//Erase every workgroup in each compute unit, setting the

--- a/src/arch/southern-islands/timing/Gpu.h
+++ b/src/arch/southern-islands/timing/Gpu.h
@@ -149,8 +149,11 @@ public:
 	/// Return the associated MMU
 	mem::Mmu *getMmu() const { return mmu.get(); }
 
-	/// Map an NDRange to the GPP object
+	/// Map an NDRange to the GPU object
 	void MapNDRange(NDRange *ndrange);
+
+	// Unmap an NDRange from the GPU
+	void UnmapNDRange(NDRange *ndrange);
 	
 	// Calculate the number of allowed work groups per wavefront pool
 	void CalcGetWorkGroupsPerWavefrontPool(

--- a/src/arch/southern-islands/timing/Gpu.h
+++ b/src/arch/southern-islands/timing/Gpu.h
@@ -73,6 +73,9 @@ private:
 	/// Number of work_groups allowed in a compute unit
 	int work_groups_per_compute_unit = 0;
 
+	/// Mapped NDRange to the GPU
+	NDRange *mapped_ndrange = nullptr;
+
 public:
 
 	//
@@ -190,6 +193,9 @@ public:
 	
 	/// Add a compute unit to the list of available compute units
 	ComputeUnit *AddComputeUnit(ComputeUnit *compute_unit);
+
+	/// Getter for the mapped NDRange of the GPU
+	NDRange *getNDRange() const { return mapped_ndrange; }
 };
 
 }

--- a/src/arch/southern-islands/timing/Timing.cc
+++ b/src/arch/southern-islands/timing/Timing.cc
@@ -1182,7 +1182,7 @@ bool Timing::Run()
 		esim_engine->Finish("SIMaxInstructions");
 
 	// Stop if there was a simulation stall
-	if (gpu->last_complete_cycle && gpu->last_complete_cycle > 1000000)
+	if (getCycle() - gpu->last_complete_cycle > 1000000)
 	{
 		std::cout<<"\n\n************TOO LONG******************\n\n";
 		//warning("Southern Islands GPU simulation stalled.\n%s",

--- a/src/memory/Frame.h
+++ b/src/memory/Frame.h
@@ -220,6 +220,9 @@ public:
 	/// the owner.
 	bool retain_owner = false;
 
+	// If true, the invalidation just happens to certain sub-blocks
+	// of a block
+	bool partial_invalidation = false;
 
 
 

--- a/src/memory/Module.cc
+++ b/src/memory/Module.cc
@@ -1247,6 +1247,9 @@ void Module::FlushCache()
 
 void Module::UpdateStats(Frame *frame)
 {
+	// Assert that the frame module is in fact the module
+	assert(this == frame->getModule());
+
 	// Record access type. I purposefully chose to record both hits and
 	// misses separately here so that we can sanity check them against
 	// the total number of accesses.

--- a/src/memory/SystemEvents.cc
+++ b/src/memory/SystemEvents.cc
@@ -562,10 +562,24 @@ void System::EventStoreHandler(esim::Event *event,
 		auto new_frame = misc::new_shared<Frame>(
 				frame->getId(),
 				module,
-				frame->tag);
+				frame->getAddress());
 		new_frame->target_module = module->getLowModuleServingAddress(frame->tag);
 		new_frame->request_direction = Frame::RequestDirectionUpDown;
 		new_frame->witness = frame->witness;
+
+		// Set the expected reply size. This might change during the
+		// down up write process, and invalidation
+		if (frame->state == Cache::BlockInvalid)
+		{
+			new_frame->reply_size = module->getBlockSize() + 8;
+			new_frame->setReplyIfHigher(Frame::ReplyAckData);
+		}
+		else
+		{
+			new_frame->reply_size = 8;
+			new_frame->setReplyIfHigher(Frame::ReplyAck);
+		}
+
 		esim_engine->Call(event_write_request,
 				new_frame,
 				event_store_unlock);
@@ -1463,6 +1477,7 @@ void System::EventEvictHandler(esim::Event *event,
 		new_frame->except_module = nullptr;
 		new_frame->set = frame->set;
 		new_frame->way = frame->way;
+		new_frame->partial_invalidation = false;
 		esim_engine->Call(event_invalidate,
 				new_frame,
 				event_evict_invalid);
@@ -1686,12 +1701,13 @@ void System::EventEvictHandler(esim::Event *event,
 		for (int z = 0; z < directory->getNumSubBlocks(); z++)
 		{
 			// Skip other sub-blocks
-			unsigned directory_entry_tag = frame->tag + 
+			unsigned directory_entry_tag = frame->tag +
 					z * target_module->getSubBlockSize();
-			assert(directory_entry_tag < frame->tag + (unsigned) target_module->getBlockSize());
-			if (directory_entry_tag < (unsigned) frame->src_tag || 
+			assert(directory_entry_tag < frame->tag + (unsigned)
+					target_module->getBlockSize());
+			if (directory_entry_tag < (unsigned) frame->src_tag ||
 					directory_entry_tag >=
-					frame->src_tag + 
+					frame->src_tag +
 					(unsigned) module->getBlockSize())
 				continue;
 
@@ -1963,8 +1979,8 @@ void System::EventWriteRequestHandler(esim::Event *event,
 		// decrease this value (during invalidate). If the request 
 		// turns out to be downup, then these values will get 
 		// overwritten.
-		frame->reply_size = module->getBlockSize() + 8;
-		frame->setReplyIfHigher(Frame::ReplyAckData);
+//		frame->reply_size = module->getBlockSize() + 8;
+//		frame->setReplyIfHigher(Frame::ReplyAckData);
 
 		// Sanity
 		assert(frame->request_direction);
@@ -2110,10 +2126,15 @@ void System::EventWriteRequestHandler(esim::Event *event,
 		auto new_frame = misc::new_shared<Frame>(
 				frame->getId(),
 				target_module,
-				0);
+				frame->getAddress());
 		new_frame->except_module = module;
 		new_frame->set = frame->set;
 		new_frame->way = frame->way;
+		assert(frame->request_direction);
+		if (frame->request_direction == Frame::RequestDirectionDownUp)
+			new_frame->partial_invalidation = false;
+		else
+			new_frame->partial_invalidation = true;
 		esim_engine->Call(event_invalidate,
 				new_frame,
 				event_write_request_exclusive);
@@ -2185,6 +2206,17 @@ void System::EventWriteRequestHandler(esim::Event *event,
 			new_frame->target_module = target_module->
 					getLowModuleServingAddress(frame->tag);
 			new_frame->request_direction = Frame::RequestDirectionUpDown;
+			if (frame->state == Cache::BlockInvalid)
+			{
+				new_frame->reply_size = target_module->getBlockSize() 
+						+ 8;
+				new_frame->setReplyIfHigher(Frame::ReplyAckData);
+			}
+			else
+			{
+				new_frame->reply_size = 8;
+				new_frame->setReplyIfHigher(Frame::ReplyAck);
+			}
 			esim_engine->Call(event_write_request,
 					new_frame,
 					event_write_request_updown_finish);
@@ -2238,19 +2270,18 @@ void System::EventWriteRequestHandler(esim::Event *event,
 			return;
 		}
 
-		// Check that address is a multiple of the module's block size.
-		// Set module as sharer and owner. */
+		// Set module as sharer and owner.
 		for (int z = 0; z < target_directory->getNumSubBlocks(); z++)
 		{
-			assert(frame->getAddress() % module->getBlockSize() == 0);
+			//assert(frame->getAddress() % module->getBlockSize() == 0);
 			unsigned directory_entry_tag = frame->tag +
 					z * target_module->getSubBlockSize();
 			assert(directory_entry_tag < frame->tag + 
 					(unsigned) target_module->getBlockSize());
-			if (directory_entry_tag < frame->getAddress() || 
-					directory_entry_tag >=
-					frame->getAddress() +
-					(unsigned) module->getBlockSize())
+			if (directory_entry_tag > frame->getAddress() || 
+					directory_entry_tag + 
+					(unsigned) module->getSubBlockSize() <=
+					frame->getAddress())
 				continue;
 
 			// Set sharer and owner
@@ -2413,11 +2444,12 @@ void System::EventWriteRequestHandler(esim::Event *event,
 	{
 		// Debug and trace
 		debug << misc::fmt("  %lld A-%lld 0x%x %s "
-				"write_request_reply\n",
+				"write_request_reply (size=%d)\n",
 				esim_engine->getTime(),
 				frame->getId(),
 				frame->tag,
-				target_module->getName().c_str());
+				target_module->getName().c_str(),
+				frame->reply_size);
 		trace << misc::fmt("mem.access "
 				"name=\"A-%lld\" "
 				"state=\"%s:write_request_reply\"\n",
@@ -3175,11 +3207,12 @@ void System::EventReadRequestHandler(esim::Event *event,
 	{
 		// Debug and trace
 		debug << misc::fmt("  %lld A-%lld 0x%x %s "
-				"read_request_reply\n",
+				"read_request_reply (size=%d)\n",
 				esim_engine->getTime(),
 				frame->getId(),
 				frame->tag,
-				target_module->getName().c_str());
+				target_module->getName().c_str(),
+				frame->reply_size);
 		trace << misc::fmt("mem.access "
 				"name=\"A-%lld\" "
 				"state=\"%s:read_request_reply\"\n",
@@ -3314,8 +3347,19 @@ void System::EventInvalidateHandler(esim::Event *event,
 					z * module->getSubBlockSize();
 			assert(directory_entry_tag < frame->tag +
 					(unsigned) module->getBlockSize());
+
+			// Skip other sub-blocks
+			if (frame->partial_invalidation &&
+					(frame->getAddress() < directory_entry_tag ||
+					frame->getAddress() >= directory_entry_tag +
+					module->getSubBlockSize()))
+				continue;
+
+			// Get the directory entry
 			Directory::Entry *directory_entry = directory->getEntry(
 					frame->set, frame->way, z);
+
+			// Process all the high level modules connected to it
 			for (int i = 0; i < directory->getNumNodes(); i++)
 			{
 				// Skip non-sharers and 'except_module'
@@ -3343,6 +3387,9 @@ void System::EventInvalidateHandler(esim::Event *event,
 							Directory::NoOwner);
 
 				// Skip mid-block sub-blocks
+				// This is to avoid sending multiple messages
+				// to invalidate the same sub-block
+				// in the higher level module
 				if (directory_entry_tag % sharer->getBlockSize())
 					continue;
 
@@ -3526,10 +3573,14 @@ void System::EventMessageHandler(esim::Event *event,
 			for (int z = 0; z < target_module->getDirectorySize(); z++)
 			{
 				// Skip other subblocks
-				if (int(frame->getAddress()) == frame->tag + z * target_module->getNumSubBlocks())
+				if (int(frame->getAddress()) == frame->tag + z * 
+						target_module->getNumSubBlocks())
 				{
 					// Clear the owner
-					Directory::Entry *dir_entry = target_directory->getEntry(frame->set, frame->way, z);
+					Directory::Entry *dir_entry = 
+							target_directory->
+							getEntry(frame->set, 
+							frame->way, z);
 					dir_entry->setOwner(-1);
 				}
 
@@ -3558,11 +3609,12 @@ void System::EventMessageHandler(esim::Event *event,
 	{
 		// Memory debug
 		debug << misc::fmt("  %lld A-%lld 0x%x %s "
-				"message_reply\n",
+				"message_reply (size=%d)\n",
 				esim_engine->getTime(),
 				frame->getId(),
 				frame->tag,
-				module->getName().c_str());
+				module->getName().c_str(),
+				frame->reply_size);
 
 		// Get source and destination node
 		net::Network *network = module->getLowNetwork();

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,8 @@
 *.o
 *.a
+*.log
+*.trs
 .deps
 Makefile
 Makefile.in
+src_*

--- a/tests/src/arch/southern-islands/emu/.gitignore
+++ b/tests/src/arch/southern-islands/emu/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp

--- a/tests/src/arch/southern-islands/timing/.gitignore
+++ b/tests/src/arch/southern-islands/timing/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp

--- a/tests/src/arch/x86/timing/.gitignore
+++ b/tests/src/arch/x86/timing/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp

--- a/tests/src/dram/.gitignore
+++ b/tests/src/dram/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp

--- a/tests/src/memory/.gitignore
+++ b/tests/src/memory/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp

--- a/tests/src/memory/TestSystemEvents.cc
+++ b/tests/src/memory/TestSystemEvents.cc
@@ -661,7 +661,7 @@ TEST(TestSystemEvents, config_0_evict_0)
 }
 
 
-// l1_0 has address 0 in S
+// l1_0 has address 0 in E 
 // l1_0 reads address 1024 and 2048 (address 0 gets evicted)
 TEST(TestSystemEvents, config_0_evict_1)
 {
@@ -701,7 +701,7 @@ TEST(TestSystemEvents, config_0_evict_1)
 		ASSERT_NE(module_mm, nullptr);
 
 		// Set block states
-		module_l1_0->getCache()->getBlock(0, 0)->setStateTag(Cache::BlockShared, 0x0);
+		module_l1_0->getCache()->getBlock(0, 0)->setStateTag(Cache::BlockExclusive, 0x0);
 		module_l1_1->getCache()->getBlock(1, 0)->setStateTag(Cache::BlockModified, 0x40);
 		module_l2_0->getCache()->getBlock(0, 0)->setStateTag(Cache::BlockExclusive, 0x0);
 		module_mm->getCache()->getBlock(0, 0)->setStateTag(Cache::BlockExclusive, 0x0);
@@ -754,11 +754,12 @@ TEST(TestSystemEvents, config_0_evict_1)
 		EXPECT_EQ(tag, 0x800);
 		EXPECT_EQ(state, Cache::BlockExclusive);
 
-		// Check sharers
-		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 1);
-		EXPECT_EQ(module_l2_0->isSharer(0, 0, 0, module_l1_0), true);
+		// Check sharers and owner for 0x0 sub-block 0 (previously
+		// in l1-0)
+		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 0);
 
-		// Check sharers
+		// Check sharers/owner for 0x40 (0x0 sub-block 1) currently
+		// owned by l1-1
 		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 1), 1);
 		EXPECT_EQ(module_l2_0->isSharer(0, 0, 1, module_l1_1), true);
 
@@ -771,7 +772,7 @@ TEST(TestSystemEvents, config_0_evict_1)
 		EXPECT_EQ(module_l2_0->isSharer(0, 2, 0, module_l1_0), true);
 
 		// Check owner
-		EXPECT_EQ(module_l2_0->getOwner(0, 0, 0), module_l1_0);
+		EXPECT_EQ(module_l2_0->getOwner(0, 0, 0), nullptr);
 
 		// Check owner
 		EXPECT_EQ(module_l2_0->getOwner(0, 0, 1), module_l1_1);
@@ -783,12 +784,15 @@ TEST(TestSystemEvents, config_0_evict_1)
 		EXPECT_EQ(module_l2_0->getOwner(0, 2, 0), module_l1_0);
 
 		// Check link
+		// Sent: 8B Rx for 0x400, 8B Rx for 0x800 and 8B for evict
+		//     which is removing sharer/owner in lower level
+		// Received: 72B for 0x400, 72B for 0x800, and 8B ACK for evict
 		net::Node *node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 16);
+		EXPECT_EQ(node->getSentBytes(), 24);
 
 		// Check link
 		node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 144);
+		EXPECT_EQ(node->getReceivedBytes(), 152);
 
 		// Check link
 		node = module_l1_1->getLowNetworkNode();
@@ -800,11 +804,11 @@ TEST(TestSystemEvents, config_0_evict_1)
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 144);
+		EXPECT_EQ(node->getSentBytes(), 152);
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 16);
+		EXPECT_EQ(node->getReceivedBytes(), 24);
 
 		// Check link
 		node = module_l2_0->getLowNetworkNode();
@@ -1235,8 +1239,7 @@ TEST(TestSystemEvents, config_0_evict_4)
 		EXPECT_EQ(state, Cache::BlockExclusive);
 
 		// Check sharers
-		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 2);
-		EXPECT_EQ(module_l2_0->isSharer(0, 0, 0, module_l1_0), true);
+		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 1);
 		EXPECT_EQ(module_l2_0->isSharer(0, 0, 0, module_l1_1), true);
 
 		// Check sharers
@@ -1247,7 +1250,9 @@ TEST(TestSystemEvents, config_0_evict_4)
 		EXPECT_EQ(module_l2_0->getNumSharers(0, 2, 0), 1);
 		EXPECT_EQ(module_l2_0->isSharer(0, 2, 0, module_l1_0), true);
 
-		// Check owner
+		// Check owner -- even though l1-1 now has exclusive access
+		// to the data, we won't update the owner state since it adds
+		// to the coherency information
 		EXPECT_EQ(module_l2_0->getOwner(0, 0, 0), nullptr);
 
 		// Check owner
@@ -1258,11 +1263,11 @@ TEST(TestSystemEvents, config_0_evict_4)
 
 		// Check link
 		net::Node *node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 16);
+		EXPECT_EQ(node->getSentBytes(), 24);
 
 		// Check link
 		node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 144);
+		EXPECT_EQ(node->getReceivedBytes(), 152);
 
 		// Check link
 		node = module_l1_1->getLowNetworkNode();
@@ -1274,11 +1279,11 @@ TEST(TestSystemEvents, config_0_evict_4)
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 144);
+		EXPECT_EQ(node->getSentBytes(), 152);
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 16);
+		EXPECT_EQ(node->getReceivedBytes(), 24);
 
 		// Check link
 		node = module_l2_0->getLowNetworkNode();
@@ -1298,6 +1303,8 @@ TEST(TestSystemEvents, config_0_evict_4)
 
 // l1_0 and l1_1 have address 0 in S
 // l1_0 reads address 1024 and 2048 (address 0 gets evicted)
+// This is disturbingly identical to the previous test. Keeping it
+// just only since the L2 is in state S
 TEST(TestSystemEvents, config_0_evict_5)
 {
 	try
@@ -1389,8 +1396,7 @@ TEST(TestSystemEvents, config_0_evict_5)
 		EXPECT_EQ(state, Cache::BlockExclusive);
 
 		// Check sharers
-		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 2);
-		EXPECT_EQ(module_l2_0->isSharer(0, 0, 0, module_l1_0), true);
+		EXPECT_EQ(module_l2_0->getNumSharers(0, 0, 0), 1);
 		EXPECT_EQ(module_l2_0->isSharer(0, 0, 0, module_l1_1), true);
 
 		// Check sharers
@@ -1402,7 +1408,7 @@ TEST(TestSystemEvents, config_0_evict_5)
 		EXPECT_EQ(module_l2_0->isSharer(0, 2, 0, module_l1_0), true);
 
 		// Check owner
-		EXPECT_EQ(module_l2_0->getOwner(0, 0, 1), nullptr);
+		EXPECT_EQ(module_l2_0->getOwner(0, 0, 0), nullptr);
 
 		// Check owner
 		EXPECT_EQ(module_l2_0->getOwner(0, 3, 0), module_l1_0);
@@ -1412,11 +1418,11 @@ TEST(TestSystemEvents, config_0_evict_5)
 
 		// Check link
 		net::Node *node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 16);
+		EXPECT_EQ(node->getSentBytes(), 24);
 
 		// Check link
 		node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 144);
+		EXPECT_EQ(node->getReceivedBytes(), 152);
 
 		// Check link
 		node = module_l1_1->getLowNetworkNode();
@@ -1428,11 +1434,11 @@ TEST(TestSystemEvents, config_0_evict_5)
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getSentBytes(), 144);
+		EXPECT_EQ(node->getSentBytes(), 152);
 
 		// Check link
 		node = module_l2_0->getHighNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 16);
+		EXPECT_EQ(node->getReceivedBytes(), 24);
 
 		// Check link
 		node = module_l2_0->getLowNetworkNode();

--- a/tests/src/memory/TestSystemEvents.cc
+++ b/tests/src/memory/TestSystemEvents.cc
@@ -4261,7 +4261,7 @@ TEST(TestSystemEvents, config_0_store_2)
 
 		// Accesses
 		int witness = -1;
-		module_l1_1->Access(Module::AccessStore, 0x40, &witness);
+		module_l1_1->Access(Module::AccessStore, 0x48, &witness);
 
 		// Simulation loop
 		esim::Engine *esim_engine = esim::Engine::getInstance();
@@ -4316,8 +4316,8 @@ TEST(TestSystemEvents, config_0_store_2)
 		// There should be no communication with l1_0 or any other
 		// sharers
 		net::Node *node = module_l1_0->getLowNetworkNode();
-		EXPECT_EQ(node->getReceivedBytes(), 8);
-		EXPECT_EQ(node->getSentBytes(), 8);
+		EXPECT_EQ(node->getReceivedBytes(), 0);
+		EXPECT_EQ(node->getSentBytes(), 0);
 
 		// Check L1-1 communications. Send a write-request, and 
 		// receives a block

--- a/tests/src/network/.gitignore
+++ b/tests/src/network/.gitignore
@@ -3,3 +3,4 @@
 .deps
 Makefile
 Makefile.in
+.dirstamp


### PR DESCRIPTION
* Not sending the extra messages in a write request if the block is in S/O/N, just send data if in I
* Partially invalidate sub-blocks, if an invalidation request is generated by a updown right request