### PR TITLE
Fix for: Make fails with 'isnan' not declared

### DIFF
--- a/src/arch/southern-islands/emulator/WorkItemIsa.cc
+++ b/src/arch/southern-islands/emulator/WorkItemIsa.cc
@@ -2338,7 +2338,7 @@ void WorkItem::ISA_V_CVT_I32_F32_Impl(Instruction *instruction)
 	else if (std::isinf(fvalue) || fvalue < std::numeric_limits<int>::min())
 		value.as_int = std::numeric_limits<int>::min();
 	// NaN, 0, -0 --> 0
-	else if (isnan(fvalue) || fvalue == 0.0f || fvalue == -0.0f)
+	else if (std::isnan(fvalue) || fvalue == 0.0f || fvalue == -0.0f)
 		value.as_int = 0;
 	else
 		value.as_int = (int) fvalue;


### PR DESCRIPTION
Make fails with on commit c34da842c8decdb6425bc2ce81c6334e3e3832bc with:

WorkItemIsa.cc: In member function ‘void SI::WorkItem::ISA_V_CVT_I32_F32_Impl(SI::Instruction*)’:
WorkItemIsa.cc:2341:23: error: ‘isnan’ was not declared in this scope
  else if (isnan(fvalue) || fvalue == 0.0f || fvalue == -0.0f)

This patch fixes it.