### PR TITLE
Unblock lib in subdirectories.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,4 @@
+!lib
 *.o
 *.a
 .deps

--- a/tests/src/.gitignore
+++ b/tests/src/.gitignore
@@ -1,3 +1,4 @@
+!lib
 *.o
 *.a
 .deps


### PR DESCRIPTION
The top level .gitignore blocks all lib directories. The .gitignore in subdirectories need to unblock them when needed.